### PR TITLE
Add logger to error builder in async_value_builder.dart and item_list…

### DIFF
--- a/lib/widgets/async/async_value_builder.dart
+++ b/lib/widgets/async/async_value_builder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:owl/misc/logger/logger.dart';
 
 class AsyncValueBuilder<T> extends ConsumerWidget {
   const AsyncValueBuilder({
@@ -86,7 +87,7 @@ class _LoadingBuilder extends StatelessWidget {
   }
 }
 
-class _ErrorBuilder extends StatelessWidget {
+class _ErrorBuilder extends StatelessWidget with LoggerMixin {
   const _ErrorBuilder({
     required this.error,
     required this.stackTrace,
@@ -100,6 +101,7 @@ class _ErrorBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (builder == null) {
+      log.fine(error.toString());
       return Center(
         child: Text(
           error.toString(),

--- a/lib/widgets/async/async_value_builder.dart
+++ b/lib/widgets/async/async_value_builder.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:owl/misc/logger/logger.dart';
 
 class AsyncValueBuilder<T> extends ConsumerWidget {
   const AsyncValueBuilder({
@@ -87,7 +86,7 @@ class _LoadingBuilder extends StatelessWidget {
   }
 }
 
-class _ErrorBuilder extends StatelessWidget with LoggerMixin {
+class _ErrorBuilder extends StatelessWidget {
   const _ErrorBuilder({
     required this.error,
     required this.stackTrace,
@@ -101,11 +100,10 @@ class _ErrorBuilder extends StatelessWidget with LoggerMixin {
   @override
   Widget build(BuildContext context) {
     if (builder == null) {
-      log.fine(error.toString());
       return Center(
-        child: Text(
+        child: SelectableText(
           error.toString(),
-          style: Theme.of(context).textTheme.headlineMedium,
+          style: Theme.of(context).textTheme.bodyMedium,
         ),
       );
     }

--- a/lib/widgets/async/item_list_builder.dart
+++ b/lib/widgets/async/item_list_builder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:owl/widgets/async/typedefs.dart';
 
 typedef ItemWidgetBuilder<T> = Widget Function(
   BuildContext context,
@@ -13,6 +14,7 @@ class ItemListBuilder<T> extends StatelessWidget {
     required this.data,
     required this.itemBuilder,
     this.loadingBuilder,
+    this.errorBuilder,
     this.physics,
     this.shrinkWrap = true,
     this.gridDelegate,
@@ -25,7 +27,10 @@ class ItemListBuilder<T> extends StatelessWidget {
   final ItemWidgetBuilder<T> itemBuilder;
 
   /// The builder that will be called when [data] is loading.
-  final WidgetBuilder? loadingBuilder;
+  final OwlLoadingBuilder? loadingBuilder;
+
+  /// The builder that will be called when [data] has an error.
+  final OwlErrorBuilder? errorBuilder;
 
   /// The physics of the scrollable widget.
   final ScrollPhysics? physics;
@@ -64,59 +69,24 @@ class ItemListBuilder<T> extends StatelessWidget {
         );
       },
       error: (e, st) {
-        // log.e(st);
-        return _ErrorBuilder(
-          error: e,
-          stackTrace: st,
+        if (errorBuilder != null) {
+          return errorBuilder!(
+            context,
+            e,
+            st,
+          );
+        }
+        return Center(
+          child: SelectableText(
+            e.toString(),
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
         );
       },
       loading: () {
-        return _LoadingBuilder(
-          builder: loadingBuilder,
-        );
+        return loadingBuilder?.call(context) ??
+            const Center(child: CircularProgressIndicator());
       },
-    );
-  }
-}
-
-/// These are copied from AsyncValueBuilder, but they might change in the future
-/// to use shimmer or something else.
-
-class _LoadingBuilder extends StatelessWidget {
-  const _LoadingBuilder({
-    this.builder,
-  });
-
-  final WidgetBuilder? builder;
-
-  @override
-  Widget build(BuildContext context) {
-    if (builder == null) {
-      return const Center(
-        child: CircularProgressIndicator(),
-      );
-    }
-
-    return builder!(context);
-  }
-}
-
-class _ErrorBuilder extends StatelessWidget {
-  const _ErrorBuilder({
-    required this.error,
-    required this.stackTrace,
-  });
-
-  final Object error;
-  final StackTrace stackTrace;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: SelectableText(
-        error.toString(),
-        style: Theme.of(context).textTheme.bodyMedium,
-      ),
     );
   }
 }

--- a/lib/widgets/async/item_list_builder.dart
+++ b/lib/widgets/async/item_list_builder.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:owl/misc/logger/logger.dart';
 
 typedef ItemWidgetBuilder<T> = Widget Function(
   BuildContext context,
@@ -14,7 +13,6 @@ class ItemListBuilder<T> extends StatelessWidget {
     required this.data,
     required this.itemBuilder,
     this.loadingBuilder,
-    this.errorBuilder,
     this.physics,
     this.shrinkWrap = true,
     this.gridDelegate,
@@ -28,9 +26,6 @@ class ItemListBuilder<T> extends StatelessWidget {
 
   /// The builder that will be called when [data] is loading.
   final WidgetBuilder? loadingBuilder;
-
-  /// The builder that will be called when [data] has an error.
-  final WidgetBuilder? errorBuilder;
 
   /// The physics of the scrollable widget.
   final ScrollPhysics? physics;
@@ -69,10 +64,10 @@ class ItemListBuilder<T> extends StatelessWidget {
         );
       },
       error: (e, st) {
+        // log.e(st);
         return _ErrorBuilder(
           error: e,
           stackTrace: st,
-          builder: errorBuilder,
         );
       },
       loading: () {
@@ -106,28 +101,22 @@ class _LoadingBuilder extends StatelessWidget {
   }
 }
 
-class _ErrorBuilder extends StatelessWidget with LoggerMixin {
+class _ErrorBuilder extends StatelessWidget {
   const _ErrorBuilder({
     required this.error,
     required this.stackTrace,
-    this.builder,
   });
 
   final Object error;
   final StackTrace stackTrace;
-  final WidgetBuilder? builder;
 
   @override
   Widget build(BuildContext context) {
-    if (builder == null) {
-      log.fine(error.toString());
-      return Center(
-        child: Text(
-          error.toString(),
-          style: Theme.of(context).textTheme.headlineMedium,
-        ),
-      );
-    }
-    return builder!(context);
+    return Center(
+      child: SelectableText(
+        error.toString(),
+        style: Theme.of(context).textTheme.bodyMedium,
+      ),
+    );
   }
 }

--- a/lib/widgets/async/item_list_builder.dart
+++ b/lib/widgets/async/item_list_builder.dart
@@ -69,24 +69,61 @@ class ItemListBuilder<T> extends StatelessWidget {
         );
       },
       error: (e, st) {
-        if (errorBuilder != null) {
-          return errorBuilder!(
-            context,
-            e,
-            st,
-          );
-        }
-        return Center(
-          child: SelectableText(
-            e.toString(),
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
+        return _ErrorBuilder(
+          error: e,
+          stackTrace: st,
+          builder: errorBuilder,
         );
       },
       loading: () {
-        return loadingBuilder?.call(context) ??
-            const Center(child: CircularProgressIndicator());
+        return _LoadingBuilder(
+          builder: loadingBuilder,
+        );
       },
     );
+  }
+}
+
+class _LoadingBuilder extends StatelessWidget {
+  const _LoadingBuilder({
+    this.builder,
+  });
+
+  final OwlLoadingBuilder? builder;
+
+  @override
+  Widget build(BuildContext context) {
+    if (builder == null) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+
+    return builder!(context);
+  }
+}
+
+class _ErrorBuilder extends StatelessWidget {
+  const _ErrorBuilder({
+    required this.error,
+    required this.stackTrace,
+    required this.builder,
+  });
+
+  final Object error;
+  final StackTrace stackTrace;
+  final OwlErrorBuilder? builder;
+
+  @override
+  Widget build(BuildContext context) {
+    if (builder == null) {
+      return Center(
+        child: SelectableText(
+          error.toString(),
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+    return builder!(context, error, stackTrace);
   }
 }

--- a/lib/widgets/async/item_list_builder.dart
+++ b/lib/widgets/async/item_list_builder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:owl/misc/logger/logger.dart';
 
 typedef ItemWidgetBuilder<T> = Widget Function(
   BuildContext context,
@@ -13,6 +14,7 @@ class ItemListBuilder<T> extends StatelessWidget {
     required this.data,
     required this.itemBuilder,
     this.loadingBuilder,
+    this.errorBuilder,
     this.physics,
     this.shrinkWrap = true,
     this.gridDelegate,
@@ -26,6 +28,9 @@ class ItemListBuilder<T> extends StatelessWidget {
 
   /// The builder that will be called when [data] is loading.
   final WidgetBuilder? loadingBuilder;
+
+  /// The builder that will be called when [data] has an error.
+  final WidgetBuilder? errorBuilder;
 
   /// The physics of the scrollable widget.
   final ScrollPhysics? physics;
@@ -64,10 +69,10 @@ class ItemListBuilder<T> extends StatelessWidget {
         );
       },
       error: (e, st) {
-        // log.e(st);
         return _ErrorBuilder(
           error: e,
           stackTrace: st,
+          builder: errorBuilder,
         );
       },
       loading: () {
@@ -101,22 +106,28 @@ class _LoadingBuilder extends StatelessWidget {
   }
 }
 
-class _ErrorBuilder extends StatelessWidget {
+class _ErrorBuilder extends StatelessWidget with LoggerMixin {
   const _ErrorBuilder({
     required this.error,
     required this.stackTrace,
+    this.builder,
   });
 
   final Object error;
   final StackTrace stackTrace;
+  final WidgetBuilder? builder;
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text(
-        error.toString(),
-        style: Theme.of(context).textTheme.headlineMedium,
-      ),
-    );
+    if (builder == null) {
+      log.fine(error.toString());
+      return Center(
+        child: Text(
+          error.toString(),
+          style: Theme.of(context).textTheme.headlineMedium,
+        ),
+      );
+    }
+    return builder!(context);
   }
 }

--- a/lib/widgets/async/typedefs.dart
+++ b/lib/widgets/async/typedefs.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+typedef OwlLoadingBuilder = Widget Function(BuildContext context);
+
+typedef OwlErrorBuilder = Widget Function(
+  BuildContext context,
+  Object error,
+  StackTrace stackTrace,
+);


### PR DESCRIPTION
…_builder.dart

This helps specifically for things like when you need an index to be created, you want to be able to click the error in the log.

And the LoggerMixin already handles if it's in release mode it will not be logged