### PR TITLE
SimpleAutoSaveTextField

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,16 @@ return ConditionalParentWidget(
   ),
   conditionalBuilder: (Widget child) => SomeParentWidget(child: child),
 );
-````
+```
+
+#### SimpleAutoSaveTextField
+
+A debounced textfield that auto-saves a specified `duration` after the controller text changes
+
+```dart
+SimpleAutoSaveTextField(
+  controller: useTextEditingControlle(),
+  duration: Duration(seconds: 5), // defaults to 1 second
+  onSave: (String value) => save(value),
+);
+```

--- a/lib/hooks/use_debounce.dart
+++ b/lib/hooks/use_debounce.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:owl/hooks/use_timeout_fn.dart';
+
+/// Flutter hook that delays invoking a function until after wait milliseconds
+/// have elapsed since the last time the debounced function was invoked.
+/// The third argument is the array of values that the debounce depends on,
+/// in the same manner as useEffect. The debounce timeout will start when one
+/// of the values changes.
+void useDebounce(VoidCallback fn, Duration delay, [List<Object?>? keys]) {
+  final timeout = useTimeoutFn(fn, delay);
+  useEffect(() => timeout.reset, keys);
+}

--- a/lib/owl.dart
+++ b/lib/owl.dart
@@ -12,4 +12,5 @@ export 'widgets/clickable.dart';
 export 'widgets/conditional_parent_widget.dart';
 export 'widgets/responsive/responsive_center.dart';
 export 'widgets/responsive/responsive_two_column_layout.dart';
+export 'widgets/simple_auto_save_text_field.dart';
 export 'widgets/unfocus.dart';

--- a/lib/widgets/simple_auto_save_text_field.dart
+++ b/lib/widgets/simple_auto_save_text_field.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:owl/hooks/use_debounce.dart';
+
+class SimpleAutoSaveTextField extends HookWidget {
+  const SimpleAutoSaveTextField({
+    super.key,
+    required this.controller,
+    required this.onSave,
+    this.duration = const Duration(seconds: 1),
+    this.onFocusChanged,
+    this.style,
+    this.decoration,
+    this.focusNode,
+    this.maxLines,
+    this.maxLength,
+  });
+
+  final TextEditingController controller;
+  final void Function(String) onSave;
+  final Duration duration;
+  final void Function(bool)? onFocusChanged;
+  final TextStyle? style;
+  final InputDecoration? decoration;
+  final FocusNode? focusNode;
+  final int? maxLines;
+  final int? maxLength;
+
+  @override
+  Widget build(BuildContext context) {
+    final mFocusNode = focusNode ?? useFocusNode();
+    useListenableSelector(
+      mFocusNode,
+      () => onFocusChanged?.call(mFocusNode.hasFocus),
+    );
+
+    useDebounce(
+      () => onSave(controller.text),
+      duration,
+      [controller.text],
+    );
+    useListenable(controller);
+
+    return TextField(
+      focusNode: mFocusNode,
+      controller: controller,
+      maxLength: maxLength,
+      maxLines: maxLines,
+      style: style,
+      decoration: decoration,
+    );
+  }
+}


### PR DESCRIPTION
A debounced textfield that auto-saves a specified `duration` after the controller text changes

```dart
SimpleAutoSaveTextField(
  controller: useTextEditingControlle(),
  duration: Duration(seconds: 5), // defaults to 1 second
  onSave: (String value) => save(value),
);